### PR TITLE
Remove unused S3 util and update method

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -82,13 +82,6 @@ S3_DIRS = {
     "PREVIEW_IMAGES": "preview_images/"  # 미리보기 이미지 디렉토리 추가
 }
 
-def get_s3_file_modified_time(s3_handler, key):
-    """S3 파일의 마지막 수정 시각을 반환 (datetime)"""
-    try:
-        response = s3_handler.s3_client.head_object(Bucket=s3_handler.bucket, Key=key)
-        return response['LastModified']
-    except Exception as e:
-        return None
     
 
 
@@ -124,12 +117,12 @@ class S3Handler:
             logger.error(f"S3 다운로드 실패 ({file_key}): {e}")
             return {"status": "error", "message": str(e)}
 
-    def get_s3_file_modified_time(s3_handler, key):
+    def get_s3_file_modified_time(self, key):
         """S3 파일의 마지막 수정 시각을 반환 (datetime)"""
         try:
-            response = s3_handler.s3_client.head_object(Bucket=s3_handler.bucket, Key=key)
-            return response['LastModified']
-        except Exception as e:
+            response = self.s3_client.head_object(Bucket=self.bucket, Key=key)
+            return response["LastModified"]
+        except Exception:
             return None
 
     def save_metadata(self, date_str, metadata):


### PR DESCRIPTION
## Summary
- delete the unused `get_s3_file_modified_time` helper
- rewrite `S3Handler.get_s3_file_modified_time` to use `self`

## Testing
- `python3 -m py_compile streamlit_app.py`

------
https://chatgpt.com/codex/tasks/task_e_683fa3850cc4832fb4583eef51da59f9